### PR TITLE
cfetch: use pacman dir instead of commands to count pkg

### DIFF
--- a/cfetch
+++ b/cfetch
@@ -160,6 +160,11 @@ getPackages() {
     # Count all queried packages.
     TOTAL_PKGS="$(count_params ${GET_PKGS})"
 
+    # Pacman adds extra one file on the directory, reduce it
+    if [ $MANAGER = 'pacman' ]; then
+      TOTAL_PKGS=$((TOTAL_PKGS - 1))
+    fi
+
     # If only zero or one package is installed,
     # make the package manager looks unrecognized.
     case "$TOTAL_PKGS" in

--- a/cfetch
+++ b/cfetch
@@ -149,7 +149,7 @@ getPackages() {
       nix-env   ) GET_PKGS="$(nix-store -q --requisites /run/current-system/sw)"
                   MANAGER='nix' # Make the NixOS package manager as "nix".
       ;;
-      pacman    ) GET_PKGS="$(pacman -Qq)"
+      pacman    ) GET_PKGS='/var/lib/pacman/local/*'
       ;;
       rpm       ) GET_PKGS="$(rpm -qa --last)"
       ;;


### PR DESCRIPTION
This should be tested first, not sure if this is working on other system or accurate.

But i can confirm this is faster than using `pacman -Qq` commands

Before:
![image](https://user-images.githubusercontent.com/69681505/152979258-30256381-c500-432c-9ea0-2e0254f94fd6.png)

After:
![image](https://user-images.githubusercontent.com/69681505/152979301-4e53dea6-b9d2-4562-a116-c21d64a76bb7.png)
